### PR TITLE
add redux to control all preferences

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -39,3 +39,4 @@ TODO:
 - [x] GT-38: create a header component.
 - [x] GT-39: refactor card component.
 - [x] GT-41: refactor a form component and add the MailSent screen.
+- [] GT-42: add redux to control all preferences.

--- a/TODO.txt
+++ b/TODO.txt
@@ -39,4 +39,4 @@ TODO:
 - [x] GT-38: create a header component.
 - [x] GT-39: refactor card component.
 - [x] GT-41: refactor a form component and add the MailSent screen.
-- [] GT-42: add redux to control all preferences.
+- [x] GT-42: add redux to control all preferences.

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0",
+    "redux": "^4.0.5",
     "styled-components": "^4.4.1",
     "yup": "^0.28.0"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,16 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import Routes from './routes';
 import GlobalStyle from './styles/global';
 
+import store from './store';
+
 function App() {
   return (
-    <>
+    <Provider store={store}>
       <Routes />
       <GlobalStyle />
-    </>
+    </Provider>
   );
 }
 

--- a/src/pages/Pets/index.js
+++ b/src/pages/Pets/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 
 import {
@@ -28,6 +29,15 @@ class Pets extends Component {
     localStorage.setItem('pets', JSON.stringify(option));
   };
 
+  handleAddPreference(preference) {
+    const { dispatch } = this.props;
+
+    dispatch({
+      type: 'ADD_PET',
+      preference,
+    });
+  }
+
   render() {
     return (
       <>
@@ -47,11 +57,11 @@ class Pets extends Component {
               for your buddy.
             </Subtitle>
             <CardGroup>
-              <Card primary onClick={() => this.setInputOption(true)}>
+              <Card primary onClick={() => this.handleAddPreference(true)}>
                 <Pet />
                 Yes
               </Card>
-              <Card primary onClick={() => this.setInputOption(false)}>
+              <Card primary onClick={() => this.handleAddPreference(false)}>
                 <NoAnswer />
                 No/They don't care
               </Card>
@@ -77,4 +87,4 @@ class Pets extends Component {
   }
 }
 
-export default Pets;
+export default connect()(Pets);

--- a/src/pages/Pets/index.js
+++ b/src/pages/Pets/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { NavLink } from 'react-router-dom';
 
 import {
@@ -18,6 +19,7 @@ import { ReactComponent as Pet } from '../../assets/icons/coral/pet.svg';
 import { ReactComponent as NoAnswer } from '../../assets/icons/coral/no-answer.svg';
 import { ReactComponent as GreenArrowRight } from '../../assets/icons/green/greenArrowRight.svg';
 import { ReactComponent as GreenArrowLeft } from '../../assets/icons/green/greenArrowLeft.svg';
+import * as PreferenceActions from '../../store/modules/preferences/actions';
 
 import Container from '../../components/Container';
 import { AskContainer } from '../../components/AskContainer';
@@ -30,12 +32,8 @@ class Pets extends Component {
   };
 
   handleAddPreference(preference) {
-    const { dispatch } = this.props;
-
-    dispatch({
-      type: 'ADD_PET',
-      preference,
-    });
+    const { addPet } = this.props;
+    addPet(preference);
   }
 
   render() {
@@ -87,4 +85,7 @@ class Pets extends Component {
   }
 }
 
-export default connect()(Pets);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(PreferenceActions, dispatch);
+
+export default connect(null, mapDispatchToProps)(Pets);

--- a/src/pages/Picks/index.js
+++ b/src/pages/Picks/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { NavLink } from 'react-router-dom';
+import store from '../../store';
 
 import { Title, IllustrationContainer } from './PicksStyles';
 import HandPick from '../../assets/illustrations/pick.png';
@@ -44,17 +45,14 @@ class Picks extends Component {
   }
 
   handleData = async e => {
-    const sunlight = JSON.parse(localStorage.getItem('sunlight'));
-    const water = JSON.parse(localStorage.getItem('water'));
-    const pets = JSON.parse(localStorage.getItem('pets'));
+    const { preferences } = store.getState();
     const response = await api.get(
-      `?sun=${sunlight}&water=${water}&pets=${pets}`
+      `?sun=${preferences.sunlight}&water=${preferences.water}&pets=${preferences.pet}`
     );
 
     this.setState({
       plants: [...this.state.plants, ...response.data],
     });
-    console.log(this.state.plants);
   };
 
   saveplant = id => {

--- a/src/pages/Sunlight/index.js
+++ b/src/pages/Sunlight/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { NavLink } from 'react-router-dom';
 import {
   Title,
@@ -23,18 +24,16 @@ import Header from '../../components/Header';
 import Logo from '../../components/Logo';
 import { Card } from '../../components/Card/Card.styled';
 
+import * as PreferenceActions from '../../store/modules/preferences/actions';
+
 class Sunlight extends Component {
   setInputOption = option => {
     localStorage.setItem('sunlight', JSON.stringify(option));
   };
 
   handleAddPreference(preference) {
-    const { dispatch } = this.props;
-
-    dispatch({
-      type: 'ADD_SUNLIGHT',
-      preference,
-    });
+    const { addSunlight } = this.props;
+    addSunlight(preference);
   }
 
   render() {
@@ -87,4 +86,7 @@ class Sunlight extends Component {
   }
 }
 
-export default connect()(Sunlight);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(PreferenceActions, dispatch);
+
+export default connect(null, mapDispatchToProps)(Sunlight);

--- a/src/pages/Sunlight/index.js
+++ b/src/pages/Sunlight/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import {
   Title,
@@ -27,6 +28,15 @@ class Sunlight extends Component {
     localStorage.setItem('sunlight', JSON.stringify(option));
   };
 
+  handleAddPreference(preference) {
+    const { dispatch } = this.props;
+
+    dispatch({
+      type: 'ADD_SUNLIGHT',
+      preference,
+    });
+  }
+
   render() {
     return (
       <>
@@ -43,15 +53,15 @@ class Sunlight extends Component {
               get.
             </Title>
             <CardGroup>
-              <Card primary onClick={() => this.setInputOption('high')}>
+              <Card primary onClick={() => this.handleAddPreference('high')}>
                 <HighSun />
                 High sunlight
               </Card>
-              <Card primary onClick={() => this.setInputOption('low')}>
+              <Card primary onClick={() => this.handleAddPreference('low')}>
                 <LowhSun />
                 Low sunlight
               </Card>
-              <Card primary onClick={() => this.setInputOption('no')}>
+              <Card primary onClick={() => this.handleAddPreference('no')}>
                 <NoAnswer />
                 No sunlight
               </Card>
@@ -77,4 +87,4 @@ class Sunlight extends Component {
   }
 }
 
-export default Sunlight;
+export default connect()(Sunlight);

--- a/src/pages/Water/index.js
+++ b/src/pages/Water/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { NavLink } from 'react-router-dom';
 
 import {
@@ -23,6 +24,7 @@ import Container from '../../components/Container';
 import { AskContainer } from '../../components/AskContainer';
 import Header from '../../components/Header';
 import Logo from '../../components/Logo';
+import * as PreferenceActions from '../../store/modules/preferences/actions';
 
 class Water extends Component {
   setInputOption = option => {
@@ -30,12 +32,8 @@ class Water extends Component {
   };
 
   handleAddPreference(preference) {
-    const { dispatch } = this.props;
-
-    dispatch({
-      type: 'ADD_WATER',
-      preference,
-    });
+    const { addWater } = this.props;
+    addWater(preference);
   }
 
   render() {
@@ -86,4 +84,8 @@ class Water extends Component {
     );
   }
 }
-export default connect()(Water);
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(PreferenceActions, dispatch);
+
+export default connect(null, mapDispatchToProps)(Water);

--- a/src/pages/Water/index.js
+++ b/src/pages/Water/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 
 import {
@@ -28,6 +29,15 @@ class Water extends Component {
     localStorage.setItem('water', JSON.stringify(option));
   };
 
+  handleAddPreference(preference) {
+    const { dispatch } = this.props;
+
+    dispatch({
+      type: 'ADD_WATER',
+      preference,
+    });
+  }
+
   render() {
     return (
       <>
@@ -43,15 +53,15 @@ class Water extends Component {
               How often do you want to <strong>water</strong> your plant?
             </Title>
             <CardGroup>
-              <Card onClick={() => this.setInputOption('rarely')}>
+              <Card onClick={() => this.handleAddPreference('rarely')}>
                 <OneDrop />
                 Rarely
               </Card>
-              <Card onClick={() => this.setInputOption('regularly')}>
+              <Card onClick={() => this.handleAddPreference('regularly')}>
                 <TwoDrops />
                 Regularly
               </Card>
-              <Card onClick={() => this.setInputOption('daily')}>
+              <Card onClick={() => this.handleAddPreference('daily')}>
                 <ThreeDrops />
                 Daily
               </Card>
@@ -76,4 +86,4 @@ class Water extends Component {
     );
   }
 }
-export default Water;
+export default connect()(Water);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,7 @@
+import { createStore } from 'redux';
+
+import rootReducer from './modules/rootReducer';
+
+const store = createStore(rootReducer);
+
+export default store;

--- a/src/store/modules/preferences/actions.js
+++ b/src/store/modules/preferences/actions.js
@@ -1,0 +1,20 @@
+export function addSunlight(preference) {
+  return {
+    type: 'ADD_SUNLIGHT',
+    preference,
+  };
+}
+
+export function addWater(preference) {
+  return {
+    type: 'ADD_WATER',
+    preference,
+  };
+}
+
+export function addPet(preference) {
+  return {
+    type: 'ADD_PET',
+    preference,
+  };
+}

--- a/src/store/modules/preferences/reducer.js
+++ b/src/store/modules/preferences/reducer.js
@@ -1,0 +1,3 @@
+export default function preferences() {
+  return ['no', 'rarely', false];
+}

--- a/src/store/modules/preferences/reducer.js
+++ b/src/store/modules/preferences/reducer.js
@@ -1,3 +1,19 @@
-export default function preferences() {
-  return ['no', 'rarely', false];
+const ADD_WATER = 'ADD_WATER';
+const ADD_SUNLIGHT = 'ADD_SUNLIGHT';
+const ADD_PET = 'ADD_PET';
+
+export default function preferences(
+  state = { sunlight: 'no', water: 'rarely', pet: false },
+  action
+) {
+  switch (action.type) {
+    case ADD_WATER:
+      return { ...state, water: action.preference };
+    case ADD_SUNLIGHT:
+      return { ...state, sunlight: action.preference };
+    case ADD_PET:
+      return { ...state, pet: action.preference };
+    default:
+      return state;
+  }
 }

--- a/src/store/modules/rootReducer.js
+++ b/src/store/modules/rootReducer.js
@@ -1,0 +1,7 @@
+import { combineReducers } from 'redux';
+
+import preferences from './preferences/reducer';
+
+export default combineReducers({
+  preferences,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,6 +944,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.5":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.4.0", "@babel/template@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
@@ -8922,10 +8929,22 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-redux@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.3.tgz#717a3d7bbe3a1b2d535c94885ce04cdc5a33fc79"
+  integrity sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-router-dom@^5.1.2:
   version "5.1.2"
@@ -9111,6 +9130,14 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
@@ -10245,6 +10272,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"


### PR DESCRIPTION
### Wha I do:
Here I'm using the `redux` to save all preferences into a store. I was using `local storage`.

### Basic Redux:
- **What's is redux**: Redux is a library (this library could be used with React, Angular, Vue and javascript vanilla) that implements the flux architecture.
- **What is redux for**: Redux is used to control globals states into an application.
- **When I need to use redux**: 
  - My state is manipulated for more than one component.
  - The user actions cause side effects into data.

:eyes:  _Look at the image below to see the redux workflow_.

**Action** send an object to our **Redux Store**, the redux store is our global state. Into our redux store, we've **Reducers**, here we can have more than one reducer, depends on your application. The reducer is responsible to mutate the state. After that our view can update the components based on our new state.

![image](https://user-images.githubusercontent.com/23489471/72763897-83daba00-3bc4-11ea-96f8-b88475ab1934.png)

### Principles:
- All actions need to have a type, and this type needs to be unique.
- The redux state is the only true point, you cannot add half state into component and half state into redux, all state needs to be into redux.
- You can't change the redux state without an action.
- Any synchronous logic for business rules should be on the reducer and never in the action.
- Not an all application needs redux, start without and use if the necessity.